### PR TITLE
Horizontal scrolling on lists

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -9,9 +9,7 @@ const { Content } = Layout
 const App = () => (
   <Layout className="appLayout">
     <Content className="appContent">
-      <main>
-        <Route exact path="/" component={BoardContainer} />
-      </main>
+      <Route exact path="/" component={BoardContainer} />
     </Content>
   </Layout>
 )

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -2,6 +2,6 @@
     height: 100vh;
 }
 
-.appLayout {
-    padding: 25px 50px;
+.appContent {
+    height: 100%;
 }

--- a/src/components/board/Board.jsx
+++ b/src/components/board/Board.jsx
@@ -5,18 +5,22 @@ import List from '../list/List'
 import './style.css'
 
 const Board = props => (
-  <div>
-    <h1>Board</h1>
-    {props.lists.map(list => (
-      <List key={list.id} {...list} />
-    ))}
-    <Button
-      className="addListButton"
-      onClick={props.addList}
-      disabled={props.isAddingList}
-      icon="plus"
-      size="large"
-    >New list</Button>
+  <div className="board">
+    <div className="boardTitle">
+      <h1>Board</h1>
+    </div>
+    <div className="listWrapper">
+      {props.lists.map(list => (
+        <List key={list.id} {...list} />
+      ))}
+      <Button
+        className="addListButton"
+        onClick={props.addList}
+        disabled={props.isAddingList}
+        icon="plus"
+        size="large"
+      >New list</Button>
+    </div>
   </div>
 )
 

--- a/src/components/board/style.css
+++ b/src/components/board/style.css
@@ -1,7 +1,23 @@
+.board {
+    height: 100%;
+    display: flex;
+    flex-flow: column nowrap;
+}
+
+.boardTitle {
+    padding: 20px;
+}
+
+.listWrapper {
+    height: inherit;
+    overflow-x: scroll;
+    white-space: nowrap;
+    padding: 0 50px 0 10px;
+}
+
 .addListButton {
-    display: inline-block;
-    margin: 25px 0 0 0;
-    position: absolute;
     opacity: 0.5;
+    margin: 0 10px 0 10px;
+    top: 20px;
     width: 300px;
 }

--- a/src/components/list/style.css
+++ b/src/components/list/style.css
@@ -1,5 +1,5 @@
 .list {
     display: inline-grid;
-    margin: 25px 25px 0 0;
+    margin: 10px;
     width: 300px;
 }


### PR DESCRIPTION
We need to scroll horizontally on lists inside the board. With Windows or Linux a scrollbar is automatically displayed, but the Mac guidelines hide this scrollbar when it's not used (it's not a issue, the Mac users know that).

Now, there is a big padding at the right of the board to allow the user to continue to see the "Add list" button even if a list has just been created (because the button is shifted to the right).

![Gif](https://media.giphy.com/media/l1J9uykw873mu9wyI/giphy.gif)