### PR TITLE
Fix bug when moving lists

### DIFF
--- a/src/components/list/style.css
+++ b/src/components/list/style.css
@@ -6,6 +6,7 @@
 
 .draggableList {
     display: inline-grid;
+    width: 390px;
 }
 
 .list > .ant-card-body {


### PR DESCRIPTION
When we move list between them, sometimes the position is bugged (see the end of the gif). 
It appears that the drag and drop library resize the width of the draggable list sometimes, so we need to force it.

![2017-10-16 22 33 20](https://user-images.githubusercontent.com/6637214/31634643-89c4bc62-b2c4-11e7-980a-cefaf73f0ed9.gif)
