### PR TITLE
Fix lists scroller and remove blank space under the lists

### DIFF
--- a/src/components/board/style.css
+++ b/src/components/board/style.css
@@ -1,4 +1,6 @@
 .board {
+    display: flex;
+    flex-direction: column;
     height: 100%;
 }
 

--- a/src/components/cards/style.css
+++ b/src/components/cards/style.css
@@ -1,7 +1,7 @@
 .cardsWrapper {
     display: flex;
     flex-direction: column;
-    height: 70vh;
+    max-height: 80vh;
     overflow-y: auto;
     padding: 0 20px 0 20px;
     width: 100%;

--- a/src/components/list/DraggableList.jsx
+++ b/src/components/list/DraggableList.jsx
@@ -15,7 +15,7 @@ const DraggableList = props => (
         >
           <List {...props} />
         </div>
-        <div className="draggableList">
+        <div>
           {draggableProvided.placeholder}
         </div>
       </div>

--- a/src/components/lists/style.css
+++ b/src/components/lists/style.css
@@ -2,6 +2,7 @@
     display: inline-flex;
     height: inherit;
     overflow-x: scroll;
+    overflow-y: hidden;
     margin: 0;
 }
 
@@ -16,6 +17,5 @@
 }
 
 .droppableLists {
-    height: 100%;
     display: flex;
 }


### PR DESCRIPTION
In the future, we must refactor this to extend the list until the bottom of the windows (currently just a percentage of the height).

![2017-10-17 10 41 45](https://user-images.githubusercontent.com/6637214/31655201-6f1d839e-b328-11e7-8ec2-5efe9239a835.gif)
