### PR TITLE
Fix save title on click outside and Fix write whitespace

### DIFF
--- a/src/commons/editField/EditField.jsx
+++ b/src/commons/editField/EditField.jsx
@@ -6,41 +6,50 @@ class EditField extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      editing: null,
+      editing: false,
       text: this.props.text,
     }
     this.onChangeText = this.onChangeText.bind(this)
+    this.enableEditing = this.enableEditing.bind(this)
+    this.saveChange = this.saveChange.bind(this)
   }
 
   onChangeText(e) {
-    this.setState({ text: e.target.value })
+    this.setState({
+      text: e.target.value,
+    })
   }
 
-  toggleEditing() {
-    this.setState({ editing: this.props.id })
+  enableEditing() {
+    this.setState({
+      editing: true,
+    })
   }
 
   saveChange() {
-    this.props.saveChange(this.state.text)
-    this.setState({ editing: null })
+    this.setState({
+      editing: false,
+    })
+    this.props.save(this.state.text)
   }
 
   renderItemOrEditField() {
-    if (this.state.editing === this.props.id) {
+    if (this.state.editing) {
       return (
         <Input
           value={this.state.text}
-          onPressEnter={() => { this.saveChange() }}
-          onBlur={() => { this.saveChange() }}
           onChange={this.onChangeText}
+          onPressEnter={this.saveChange}
+          onBlur={this.saveChange}
           onMouseDown={e => e.stopPropagation()}
+          autoFocus
         />
       )
     } 
     return (
-      <p onClick={this.toggleEditing.bind(this, this.props.id)}>
+      <span {...this.props.dragHandleProps} onClick={this.enableEditing}>
         {this.state.text}
-      </p>
+      </span>
     )
   }
 
@@ -50,9 +59,9 @@ class EditField extends Component {
 }
 
 EditField.propTypes = {
-  id: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
-  saveChange: PropTypes.func.isRequired,
-
+  save: PropTypes.func.isRequired,
+  dragHandleProps: PropTypes.object.isRequired,
 }
+
 export default EditField

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -9,11 +9,11 @@ import EditField from '../../commons/editField/EditField'
 class Card extends Component {
   getHeader() {
     return (
-      <div className="cardHeader" {...this.props.dragHandleProps}>
+      <div className="cardHeader">
         <EditField
-          id={this.props.id}
           text={this.props.title}
-          saveChange={(newTitle) => { this.props.saveCardTitle(this.props.id, newTitle) }}
+          save={(newTitle) => { this.props.saveCardTitle(this.props.id, newTitle) }}
+          dragHandleProps={this.props.dragHandleProps}
         />
       </div>
     )
@@ -60,6 +60,7 @@ Card.propTypes = {
   rank: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
   deleteCard: PropTypes.func.isRequired,
+  saveCardTitle: PropTypes.func.isRequired,
   dragHandleProps: PropTypes.object.isRequired,
 }
 

--- a/src/components/list/List.jsx
+++ b/src/components/list/List.jsx
@@ -7,21 +7,13 @@ import './style.css'
 import EditField from '../../commons/editField/EditField'
 
 class List extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      editing: null,
-      title: this.props.title,
-    }
-  }
-      
   getHeader() {
     return (
-      <div className="listHeader" {...this.props.dragHandleProps}>
+      <div className="listHeader">
         <EditField
-          id={this.props.id}
           text={this.props.title}
-          saveChange={(newTitle) => { this.props.saveTitleList(this.props.id, newTitle) }}
+          save={(newTitle) => { this.props.saveTitleList(this.props.id, newTitle) }}
+          dragHandleProps={this.props.dragHandleProps}
         />
       </div>
     )
@@ -59,7 +51,8 @@ class List extends Component {
         className="list" 
         title={this.getHeader()} 
         extra={this.getDropdown()} 
-        bordered={false}>
+        bordered={false}
+      >
         <CardsContainer listId={this.props.id} />
       </UIList>
     )

--- a/src/components/lists/Lists.jsx
+++ b/src/components/lists/Lists.jsx
@@ -24,7 +24,7 @@ Lists.propTypes = {
   lists: PropTypes.array.isRequired,
   addList: PropTypes.func.isRequired,
   deleteList: PropTypes.func.isRequired,
-  saveTitleList: PropTypes.func.isRequired
+  saveTitleList: PropTypes.func.isRequired,
 }
 
 export default Lists


### PR DESCRIPTION
There are some issues with edit title:
* We can't save the title when we click on specific points outside the input
* We can't type whitespace

Those issues come from the Drag and Drop context which apply some handlers on those events (clicks and type whitespace).

![2017-10-22 23 02 09](https://user-images.githubusercontent.com/6637214/31866266-6049af9c-b77d-11e7-8eb9-6ad95ac5344a.gif)
 