### PR TITLE
Show loaders when fetching and adding data 

### DIFF
--- a/src/components/boards/Boards.jsx
+++ b/src/components/boards/Boards.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Layout } from 'antd'
+import { Layout, Spin } from 'antd'
 import { Grid, Row, Col } from 'react-flexbox-grid'
 import BoardPreview from '../boardPreview/BoardPreview'
 import './style.css'
@@ -10,21 +10,28 @@ const { Content } = Layout
 const Boards = props => (
   <Layout className="boardsLayout">
     <Content className="boardsContent">
-      <Grid fluid>
-        <Row>
-          {props.boards.map(board => (
-            <Col xs={12} sm={6} md={4} lg={3} key={board.id}>
-              <BoardPreview {...board} />
-            </Col>
-          ))}
-        </Row>
-      </Grid>
+      { props.isFetching ? (
+        <div className="boardsLoader">
+          <Spin tip="Loading your boards..." />
+        </div>
+      ) : (
+        <Grid fluid>
+          <Row>
+            {props.boards.map(board => (
+              <Col xs={12} sm={6} md={4} lg={3} key={board.id}>
+                <BoardPreview {...board} />
+              </Col>
+            ))}
+          </Row>
+        </Grid>
+      )}
     </Content>
   </Layout>
 )
 
 Boards.propTypes = {
   boards: PropTypes.array.isRequired,
+  isFetching: PropTypes.bool.isRequired,
 }
 
 export default Boards

--- a/src/components/boards/style.css
+++ b/src/components/boards/style.css
@@ -1,3 +1,8 @@
 .boardsContent {
     padding: 0 10ch;
 }
+
+.boardsLoader {
+    padding: 50px;
+    text-align: center;
+}

--- a/src/components/cards/Cards.jsx
+++ b/src/components/cards/Cards.jsx
@@ -15,15 +15,21 @@ const Cards = props => (
         {props.cards.sort((a, b) => a.rank > b.rank).map(card => (
           <DraggableCard {...card} key={card.id} deleteCard={props.deleteCard} saveCardTitle={props.saveCardTitle} />
         ))}
-        <div className="addCardBlock">
-          <Button
-            className="addCardButton"
-            onClick={() => props.addCard(props.listId, props.cards.length)}
-            icon="plus"
-            size="large"
-            type="primary"
-          >New Card</Button>
-        </div>
+        { props.isAdding ? (
+          <div className="cardsLoader">
+            <Spin tip="Creating a card..." />
+          </div>
+        ) : (
+          <div className="addCardBlock">
+            <Button
+              className="addCardButton"
+              onClick={() => props.addCard(props.listId, props.cards.length)}
+              icon="plus"
+              size="large"
+              type="primary"
+            >New Card</Button>
+          </div>
+        )}
       </div>
     )}
   </div>
@@ -33,6 +39,7 @@ Cards.propTypes = {
   listId: PropTypes.string.isRequired,
   cards: PropTypes.array.isRequired,
   isFetching: PropTypes.bool.isRequired,
+  isAdding: PropTypes.bool.isRequired,
   addCard: PropTypes.func.isRequired,
   deleteCard: PropTypes.func.isRequired,
   saveCardTitle: PropTypes.func.isRequired,

--- a/src/components/cards/Cards.jsx
+++ b/src/components/cards/Cards.jsx
@@ -1,29 +1,38 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button } from 'antd'
+import { Button, Spin } from 'antd'
 import DraggableCard from '../card/DraggableCard'
 import './style.css'
 
 const Cards = props => (
-  <div className="cardsWrapper">
-    {props.cards.sort((a, b) => a.rank > b.rank).map(card => (
-      <DraggableCard {...card} key={card.id} deleteCard={props.deleteCard} saveCardTitle={props.saveCardTitle} />
-    ))}
-    <div className="addCardBlock">
-      <Button
-        className="addCardButton"
-        onClick={() => props.addCard(props.listId, props.cards.length)}
-        icon="plus"
-        size="large"
-        type="primary"
-      >New Card</Button>
-    </div>
+  <div className="cards">
+    { props.isFetching ? (
+      <div className="cardsLoader">
+        <Spin tip="Loading..." />
+      </div>
+    ) : (
+      <div className="cardsWrapper">
+        {props.cards.sort((a, b) => a.rank > b.rank).map(card => (
+          <DraggableCard {...card} key={card.id} deleteCard={props.deleteCard} saveCardTitle={props.saveCardTitle} />
+        ))}
+        <div className="addCardBlock">
+          <Button
+            className="addCardButton"
+            onClick={() => props.addCard(props.listId, props.cards.length)}
+            icon="plus"
+            size="large"
+            type="primary"
+          >New Card</Button>
+        </div>
+      </div>
+    )}
   </div>
 )
 
 Cards.propTypes = {
   listId: PropTypes.string.isRequired,
-  cards: PropTypes.array.isRequired,  
+  cards: PropTypes.array.isRequired,
+  isFetching: PropTypes.bool.isRequired,
   addCard: PropTypes.func.isRequired,
   deleteCard: PropTypes.func.isRequired,
   saveCardTitle: PropTypes.func.isRequired,

--- a/src/components/cards/style.css
+++ b/src/components/cards/style.css
@@ -18,6 +18,10 @@
     text-align: center;
 }
 
+.cardsCreater {
+    text-align: center;
+}
+
 .addCardBlock {
     display: inline-flex;
     margin: 15px 0 0 0;

--- a/src/components/cards/style.css
+++ b/src/components/cards/style.css
@@ -1,3 +1,9 @@
+.cards {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
 .cardsWrapper {
     display: flex;
     flex-direction: column;
@@ -5,6 +11,11 @@
     overflow-y: auto;
     padding: 0 20px 0 20px;
     width: 100%;
+}
+
+.cardsLoader {
+    padding: 50px;
+    text-align: center;
 }
 
 .addCardBlock {

--- a/src/components/lists/Lists.jsx
+++ b/src/components/lists/Lists.jsx
@@ -1,28 +1,39 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button } from 'antd'
+import { Button, Spin } from 'antd'
 import DraggableList from '../list/DraggableList'
 import './style.css'
 
 const Lists = props => (
-  <div className="listsWrapper">
-    {props.lists.sort((a, b) => a.rank > b.rank).map(list => (
-      <DraggableList {...list} key={list.id} deleteList={props.deleteList} saveTitleList={props.saveTitleList} />
-    ))}
-    <div className="addListBlock">
-      <Button
-        className="addListButton"
-        onClick={() => props.addList(props.boardId, props.lists.length)}
-        icon="plus"
-        size="large"
-      >New list</Button>
-    </div>
+  <div className="lists">
+    { props.isFetching ? (
+      <div className="listsLoader">
+        <Spin tip="Loading the lists..." />
+      </div>
+    ) : (
+      <div className="listsWrapper">
+        {props.lists.sort((a, b) => a.rank > b.rank).map(list => (
+          <DraggableList {...list} key={list.id} deleteList={props.deleteList} saveTitleList={props.saveTitleList} />
+        ))}
+        <div className="addListBlock">
+          <Button
+            className="addListButton"
+            onClick={() => props.addList(props.boardId, props.lists.length)}
+            icon="plus"
+            size="large"
+          >
+            New list
+          </Button>
+        </div>
+      </div>
+    )}
   </div>
 )
 
 Lists.propTypes = {
   boardId: PropTypes.string.isRequired,
   lists: PropTypes.array.isRequired,
+  isFetching: PropTypes.bool.isRequired,
   addList: PropTypes.func.isRequired,
   deleteList: PropTypes.func.isRequired,
   saveTitleList: PropTypes.func.isRequired,

--- a/src/components/lists/Lists.jsx
+++ b/src/components/lists/Lists.jsx
@@ -16,14 +16,16 @@ const Lists = props => (
           <DraggableList {...list} key={list.id} deleteList={props.deleteList} saveTitleList={props.saveTitleList} />
         ))}
         <div className="addListBlock">
-          <Button
-            className="addListButton"
-            onClick={() => props.addList(props.boardId, props.lists.length)}
-            icon="plus"
-            size="large"
-          >
-            New list
-          </Button>
+          <Spin spinning={props.isAdding}>
+            <Button
+              className="addListButton"
+              onClick={() => props.addList(props.boardId, props.lists.length)}
+              icon="plus"
+              size="large"
+            >
+              New list
+            </Button>
+          </Spin>
         </div>
       </div>
     )}
@@ -34,6 +36,7 @@ Lists.propTypes = {
   boardId: PropTypes.string.isRequired,
   lists: PropTypes.array.isRequired,
   isFetching: PropTypes.bool.isRequired,
+  isAdding: PropTypes.bool.isRequired,
   addList: PropTypes.func.isRequired,
   deleteList: PropTypes.func.isRequired,
   saveTitleList: PropTypes.func.isRequired,

--- a/src/components/lists/style.css
+++ b/src/components/lists/style.css
@@ -1,9 +1,20 @@
+.lists {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
 .listsWrapper {
     display: inline-flex;
     height: inherit;
     overflow-x: scroll;
     overflow-y: hidden;
     margin: 0;
+}
+
+.listsLoader {
+    padding: 50px;
+    text-align: center;
 }
 
 .addListBlock {

--- a/src/containers/board/BoardContainer.jsx
+++ b/src/containers/board/BoardContainer.jsx
@@ -7,7 +7,7 @@ import { cleanState as cleanBoardState, getAllListsInBoard } from './actions'
 import { cleanState as cleanListsState, saveListRank } from '../lists/actions'
 import { cleanState as cleanCardsState, getAllCardsInList, saveCardRank } from '../cards/actions'
 
-class BoardsContainer extends Component {
+class BoardContainer extends Component {
   componentWillMount() {
     this.props.cleanBoardState()
     this.props.cleanListsState()
@@ -22,7 +22,7 @@ class BoardsContainer extends Component {
   }
 }
 
-BoardsContainer.propTypes = {
+BoardContainer.propTypes = {
   match: PropTypes.object.isRequired,
   cleanBoardState: PropTypes.func.isRequired,
   cleanListsState: PropTypes.func.isRequired,
@@ -34,8 +34,8 @@ BoardsContainer.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  lists: state.lists, // .filter(list => list.boardId === props.boardId),
-  cards: state.cards,
+  lists: state.lists.data,
+  cards: state.cards.data,
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({
@@ -51,4 +51,4 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(BoardsContainer)
+)(BoardContainer)

--- a/src/containers/board/reducer.js
+++ b/src/containers/board/reducer.js
@@ -6,7 +6,7 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${CLEAN_STATE}`:
-      return {}
+      return initialState
     case `${GET_ALL_LISTS_IN_BOARD}_SENT`:
       return {
         ...state,

--- a/src/containers/boards/BoardsContainer.jsx
+++ b/src/containers/boards/BoardsContainer.jsx
@@ -22,7 +22,8 @@ BoardsContainer.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  boards: state.boards,
+  boards: state.boards.data,
+  isFetching: state.boards.isFetching,
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/containers/boards/reducer.js
+++ b/src/containers/boards/reducer.js
@@ -1,15 +1,27 @@
 import { GET_ALL_BOARDS } from './constants'
 
-const initialState = []
+const initialState = {
+  data: [],
+  isFetching: false,
+}
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case `${GET_ALL_BOARDS}_SENT`:
-      return state
+    case `${GET_ALL_BOARDS}`:
+      return {
+        ...state,
+        isFetching: true,
+      }
     case `${GET_ALL_BOARDS}_SUCCESS`:
-      return action.payload.data
+      return {
+        data: action.payload.data,
+        isFetching: false,
+      }
     case `${GET_ALL_BOARDS}_ERROR`:
-      return state
+      return {
+        ...state,
+        isFetching: false,
+      }
     default:
       return state
   }

--- a/src/containers/cards/CardsContainer.jsx
+++ b/src/containers/cards/CardsContainer.jsx
@@ -24,6 +24,7 @@ CardsContainer.propTypes = {
 
 const mapStateToProps = (state, props) => ({
   cards: state.cards.data.filter(card => card.listId === props.listId),
+  isAdding: state.cards.isAddingListIds.includes(props.listId),
   isFetching: state.cards.isFetchingListIds.includes(props.listId),
 })
 

--- a/src/containers/cards/CardsContainer.jsx
+++ b/src/containers/cards/CardsContainer.jsx
@@ -23,7 +23,8 @@ CardsContainer.propTypes = {
 }
 
 const mapStateToProps = (state, props) => ({
-  cards: state.cards.filter(card => card.listId === props.listId),
+  cards: state.cards.data.filter(card => card.listId === props.listId),
+  isFetching: state.cards.isFetchingListIds.includes(props.listId),
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/containers/cards/actions.js
+++ b/src/containers/cards/actions.js
@@ -9,6 +9,7 @@ export const cleanState = () => (dispatch) => {
 export const getAllCardsInList = listId => (dispatch) => {
   dispatch({
     type: GET_ALL_CARDS_IN_LIST,
+    listId,
     payload: {
       request: {
         method: 'GET',

--- a/src/containers/cards/actions.js
+++ b/src/containers/cards/actions.js
@@ -22,6 +22,7 @@ export const getAllCardsInList = listId => (dispatch) => {
 export const addCard = (listId, lastCardRank) => (dispatch) => {
   dispatch({
     type: ADD_CARD,
+    listId,
     payload: {
       request: {
         method: 'POST',

--- a/src/containers/cards/constants.js
+++ b/src/containers/cards/constants.js
@@ -4,4 +4,3 @@ export const DELETE_CARD = 'cards/DELETE_CARD'
 export const GET_ALL_CARDS_IN_LIST = 'cards/GET_ALL_CARDS_IN_LIST'
 export const SAVE_CARD_RANK = 'cards/SAVE_CARD_RANK'
 export const SAVE_CARD_TITLE = 'cards/SAVE_CARD_TITLE'
-

--- a/src/containers/cards/reducer.js
+++ b/src/containers/cards/reducer.js
@@ -2,6 +2,7 @@ import { CLEAN_STATE, ADD_CARD, DELETE_CARD, GET_ALL_CARDS_IN_LIST } from './con
 
 const initialState = {
   data: [],
+  isAddingListIds: [],
   isFetchingListIds: [],
 }
 
@@ -9,10 +10,21 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case `${CLEAN_STATE}`:
       return initialState
+    case `${ADD_CARD}`:
+      return {
+        ...state,
+        isAddingListIds: state.isAddingListIds.concat(action.listId),
+      }
     case `${ADD_CARD}_SUCCESS`:
       return {
         ...state,
         data: state.data.concat(action.payload.data),
+        isAddingListIds: state.isAddingListIds.filter(id => id !== action.meta.previousAction.listId),
+      }
+    case `${ADD_CARD}_ERROR`:
+      return {
+        ...state,
+        isAddingListIds: state.isAddingListIds.filter(id => id !== action.meta.previousAction.listId),
       }
     case `${DELETE_CARD}_SUCCESS`:
       return {
@@ -26,6 +38,7 @@ export default (state = initialState, action) => {
       }
     case `${GET_ALL_CARDS_IN_LIST}_SUCCESS`:
       return {
+        ...state,
         data: state.data.concat(action.payload.data),
         isFetchingListIds: state.isFetchingListIds.filter(id => id !== action.meta.previousAction.listId),
       }

--- a/src/containers/cards/reducer.js
+++ b/src/containers/cards/reducer.js
@@ -1,35 +1,39 @@
-import { CLEAN_STATE, ADD_CARD, DELETE_CARD, GET_ALL_CARDS_IN_LIST, SAVE_CARD_TITLE } from './constants'
+import { CLEAN_STATE, ADD_CARD, DELETE_CARD, GET_ALL_CARDS_IN_LIST } from './constants'
 
-const initialState = []
+const initialState = {
+  data: [],
+  isFetchingListIds: [],
+}
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${CLEAN_STATE}`:
-      return []
-    case `${ADD_CARD}_SENT`:
-      return state
+      return initialState
     case `${ADD_CARD}_SUCCESS`:
-      return state.concat(action.payload.data)
-    case `${ADD_CARD}_ERROR`:
-      return state
-    case `${DELETE_CARD}_SENT`:
-      return state
+      return {
+        ...state,
+        data: state.data.concat(action.payload.data),
+      }
     case `${DELETE_CARD}_SUCCESS`:
-      return state.filter(card => card.id !== action.meta.previousAction.cardId)
-    case `${DELETE_CARD}_ERROR`:
-      return state
-    case `${GET_ALL_CARDS_IN_LIST}_SENT`:
-      return state
+      return {
+        ...state,
+        data: state.data.filter(card => card.id !== action.meta.previousAction.cardId),
+      }
+    case `${GET_ALL_CARDS_IN_LIST}`:
+      return {
+        ...state,
+        isFetchingListIds: state.isFetchingListIds.concat(action.listId),
+      }
     case `${GET_ALL_CARDS_IN_LIST}_SUCCESS`:
-      return state.concat(action.payload.data)
+      return {
+        data: state.data.concat(action.payload.data),
+        isFetchingListIds: state.isFetchingListIds.filter(id => id !== action.meta.previousAction.listId),
+      }
     case `${GET_ALL_CARDS_IN_LIST}_ERROR`:
-      return state
-    case `${SAVE_CARD_TITLE}_SENT`:
-      return state
-    case `${SAVE_CARD_TITLE}_SUCCESS`:
-      return state
-    case `${SAVE_CARD_TITLE}_ERROR`:
-      return state
+      return {
+        ...state,
+        isFetchingListIds: state.isFetchingListIds.filter(id => id !== action.meta.previousAction.listId),
+      }
     default:
       return state
   }

--- a/src/containers/lists/ListsContainer.jsx
+++ b/src/containers/lists/ListsContainer.jsx
@@ -23,7 +23,8 @@ ListsContainer.propTypes = {
 }
 
 const mapStateToProps = (state, props) => ({
-  lists: state.lists.filter(list => list.boardId === props.boardId),
+  lists: state.lists.data.filter(list => list.boardId === props.boardId),
+  isFetching: state.lists.isFetching,
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/containers/lists/ListsContainer.jsx
+++ b/src/containers/lists/ListsContainer.jsx
@@ -25,6 +25,7 @@ ListsContainer.propTypes = {
 const mapStateToProps = (state, props) => ({
   lists: state.lists.data.filter(list => list.boardId === props.boardId),
   isFetching: state.lists.isFetching,
+  isAdding: state.lists.isAdding,
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/containers/lists/reducer.js
+++ b/src/containers/lists/reducer.js
@@ -1,35 +1,39 @@
-import { CLEAN_STATE, ADD_LIST, DELETE_LIST, GET_ALL_LISTS_IN_BOARD, RENAME_LIST } from './constants'
+import { CLEAN_STATE, ADD_LIST, DELETE_LIST, GET_ALL_LISTS_IN_BOARD } from './constants'
 
-const initialState = []
+const initialState = {
+  data: [],
+  isFetching: false,
+}
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case `${CLEAN_STATE}`:
-      return []
-    case `${ADD_LIST}_SENT`:
-      return state
+      return initialState
     case `${ADD_LIST}_SUCCESS`:
-      return state.concat(action.payload.data)
-    case `${ADD_LIST}_ERROR`:
-      return state
-    case `${DELETE_LIST}_SENT`:
-      return state
+      return {
+        ...state,
+        data: state.data.concat(action.payload.data),
+      }
     case `${DELETE_LIST}_SUCCESS`:
-      return state.filter(list => list.id !== action.meta.previousAction.listId)
-    case `${DELETE_LIST}_ERROR`:
-      return state
-    case `${GET_ALL_LISTS_IN_BOARD}_SENT`:
-      return state
+      return {
+        ...state,
+        data: state.data.filter(list => list.id !== action.meta.previousAction.listId),
+      }
+    case `${GET_ALL_LISTS_IN_BOARD}`:
+      return {
+        ...state,
+        isFetching: true,
+      }
     case `${GET_ALL_LISTS_IN_BOARD}_SUCCESS`:
-      return action.payload.data
+      return {
+        data: action.payload.data,
+        isFetching: false,
+      }
     case `${GET_ALL_LISTS_IN_BOARD}_ERROR`:
-      return state
-    case `${RENAME_LIST}_SENT`:
-      return state
-    case `${RENAME_LIST}_SUCCESS`:
-      return state
-    case `${RENAME_LIST}_ERROR`:
-      return state
+      return {
+        ...state,
+        isFetching: false,
+      }
     default:
       return state
   }

--- a/src/containers/lists/reducer.js
+++ b/src/containers/lists/reducer.js
@@ -2,6 +2,7 @@ import { CLEAN_STATE, ADD_LIST, DELETE_LIST, GET_ALL_LISTS_IN_BOARD } from './co
 
 const initialState = {
   data: [],
+  isAdding: false,
   isFetching: false,
 }
 
@@ -9,10 +10,21 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case `${CLEAN_STATE}`:
       return initialState
+    case `${ADD_LIST}`:
+      return {
+        ...state,
+        isAdding: true,
+      }
     case `${ADD_LIST}_SUCCESS`:
       return {
         ...state,
         data: state.data.concat(action.payload.data),
+        isAdding: false,
+      }
+    case `${ADD_LIST}_ERROR`:
+      return {
+        ...state,
+        isAdding: false,
       }
     case `${DELETE_LIST}_SUCCESS`:
       return {
@@ -26,6 +38,7 @@ export default (state = initialState, action) => {
       }
     case `${GET_ALL_LISTS_IN_BOARD}_SUCCESS`:
       return {
+        ...state,
         data: action.payload.data,
         isFetching: false,
       }


### PR DESCRIPTION
Useful in production when the client needs to wake up the API.

When we fetch boards, lists, cards:

![2017-10-26 00 23 21](https://user-images.githubusercontent.com/6637214/32027282-75a15206-b9e8-11e7-875b-b84f04ff9a41.gif)

When we add a new list, a new card:

![2017-10-26 00 30 07](https://user-images.githubusercontent.com/6637214/32027289-80d731e0-b9e8-11e7-9761-38d7a7dca2bc.gif)

I've also delete the useless actions in reducers (they fall in the `default` case).
