### PR TITLE
FIX Rename board hit /api

### DIFF
--- a/src/containers/board/actions.js
+++ b/src/containers/board/actions.js
@@ -36,7 +36,7 @@ export const saveBoardTitle = (boardId, boardTitle) => (dispatch) => {
     payload: {
       request: {
         method: 'PUT',
-        url: `/boards/${boardId}`,
+        url: `/api/boards/${boardId}`,
         data: {
           title: boardTitle,
         },


### PR DESCRIPTION
... because the previous PR was too old !